### PR TITLE
docs: Add version checking instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,16 @@ To update `phpv` to the latest version from the repository:
 phpv --self-update
 ```
 
+### Checking Version
+
+To check the current installed version of `phpv`:
+
+```bash
+phpv -v
+# or
+phpv --version
+```
+
 ### Troubleshooting
 
 #### c-client Dependency

--- a/phpv
+++ b/phpv
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Color definitions
-VERSION="1.1.0"
+VERSION="1.3.0"
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'


### PR DESCRIPTION
Expand documentation to include how users can check the
current installed version of phpv using `-v` or
`--version` flags. Bump version number to reflect recent
changes and improvements.